### PR TITLE
Fix for issue #1

### DIFF
--- a/lib/sinatra/activerecord/rake.rb
+++ b/lib/sinatra/activerecord/rake.rb
@@ -1,4 +1,4 @@
-require 'activerecord'
+require 'active_record'
 require 'fileutils'
 
 namespace :db do


### PR DESCRIPTION
Running rake currently results in the following:
    rake aborted!
    no such file to load -- activerecord

I've corrected this in `lib/sinatra/activerecord/rake.rb` to require `active_record` instead of `activerecord` which resolves the issue (see bmizerany/sinatra-activerecord#1).
