### PR TITLE
Add the ability to specify a path to a database file

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ the following code in about anywhere and it'll work just fine:
       erb :foos
     end
 
+### Database file locations
+
+Giving a path to an SQLite database via a URL is slightly painful... far too
+many slashes are needed.  If you want to give a relative path, then you must
+use three slashes before your path name:
+
+    sqlite:///db/foo.db
+
+An absolute path has *four* slashes (an extra one to indicate "absolute
+path"):
+
+    sqlite:////home/foo/db/bar.db
+
 ### NOTE about the rip-off
 
   This Code and README.md is a heavy adaption of [rtomayko's sinatra-sequel](http://github.com/rtomayko/sinatra-sequel/)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ path"):
 
     sqlite:////home/foo/db/bar.db
 
+### Using a YAML config file
+
+If you want to store your database environment configurations in a YAML
+file, Rails-style, simply tell your app all about it:
+
+    set :database_config_yaml, "/path/to/some/file.yaml"
+
+And SAR will load the file and configure ActiveRecord appropriately.  It
+will automatically key off your pre-existing `:environment` variable to
+decide which database to connect to.
+
+
 ### NOTE about the rip-off
 
   This Code and README.md is a heavy adaption of [rtomayko's sinatra-sequel](http://github.com/rtomayko/sinatra-sequel/)

--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -42,7 +42,6 @@ module Sinatra
       case url.scheme
       when "sqlite"
         options[:adapter] = "sqlite3"
-        options[:database] = url.host
       when "postgres"
         options[:adapter] = "postgresql"
       end

--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -22,8 +22,8 @@ module Sinatra
       @database ||= (
         url = URI(database_url)
         ActiveRecord::Base.logger = activerecord_logger
-        ActiveRecord::Base.configurations[environment] = database_options
-        ActiveRecord::Base.establish_connection(environment)
+        ActiveRecord::Base.configurations[environment.to_s] = database_options
+        ActiveRecord::Base.establish_connection(environment.to_s)
         ActiveRecord::Base
       )
     end

--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -22,7 +22,8 @@ module Sinatra
       @database ||= (
         url = URI(database_url)
         ActiveRecord::Base.logger = activerecord_logger
-        ActiveRecord::Base.establish_connection(database_options)
+        ActiveRecord::Base.configurations[environment] = database_options
+        ActiveRecord::Base.establish_connection(environment)
         ActiveRecord::Base
       )
     end

--- a/sinatra-activerecord.gemspec
+++ b/sinatra-activerecord.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w[README.md]
   s.add_dependency 'sinatra',    '>= 0.9.4'
 
-  s.has_rdoc = true
   s.homepage = "http://github.com/rtomayko/sinatra-activerecord"
   s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Sinatra::ActiveRecord"]
   s.require_paths = %w[lib]

--- a/test/sinatra_activerecord_test.rb
+++ b/test/sinatra_activerecord_test.rb
@@ -1,6 +1,6 @@
 require 'test/unit'
 require 'sinatra/base'
-require 'sinatra/activerecord'
+require File.expand_path('../../lib/sinatra/activerecord', __FILE__)
 
 class MockSinatraApp < Sinatra::Base
   register Sinatra::ActiveRecordExtension

--- a/test/sinatra_activerecord_test.rb
+++ b/test/sinatra_activerecord_test.rb
@@ -1,3 +1,4 @@
+require 'test/unit'
 require 'sinatra/base'
 require 'sinatra/activerecord'
 
@@ -32,4 +33,13 @@ class TestSinatraActiveRecord < Test::Unit::TestCase
     assert @app.database.respond_to? :table_exists?
   end
 
+  def test_db_urls_with_a_path
+    @app.database = 'sqlite:///test/foo.db'
+    assert_equal 'test/foo.db', @app.database.connection.instance_variable_get(:@config)[:database]
+  end
+  
+  def test_db_urls_with_absolute_path
+    @app.database = 'sqlite:////tmp/foo.db'
+    assert_equal '/tmp/foo.db', @app.database.connection.instance_variable_get(:@config)[:database]
+  end
 end


### PR DESCRIPTION
At present, attempting to point to an sqlite file in a subdirectory or via an absolute path fails spectacularly.  This patch provides an update to the README, a couple of tests, and a trivial modification that makes this possible.

I can't work out why the tests I've written actually cause a DB file to be created, while the existing tests don't.  AR internals aren't my strong point.
