### PR TITLE
Set up an after hook to clear active connections after each request

### DIFF
--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -55,6 +55,10 @@ module Sinatra
       app.set :activerecord_logger, Logger.new(STDOUT)
       app.database # force connection
       app.helpers ActiveRecordHelper
+      
+      app.after do
+        ActiveRecord::Base.clear_active_connections!
+      end
     end
   end
 


### PR DESCRIPTION
Recent versions of ActiveRecord don't automatically release connections back into the pool.  Without this patch, the user has to manually set up this hook if they don't want every nth request to hang for 5 seconds (where n is the number of connections in the pool).
